### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,10 @@ import os
 import sys
 from datetime import datetime
 from werkzeug.utils import secure_filename
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.ERROR, filename='app.log', format='%(asctime)s %(levelname)s:%(message)s')
 
 # Ensure repository path is accessible
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -54,7 +58,8 @@ def process_query():
         return jsonify(result)
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        logging.error("Error processing query: %s", str(e))
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @app.route("/api/categories", methods=["GET"])
@@ -68,7 +73,8 @@ def get_categories():
         conn.close()
         return jsonify({"categories": categories})
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        logging.error("Error fetching categories: %s", str(e))
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @app.route("/api/items", methods=["POST"])


### PR DESCRIPTION
Potential fix for [https://github.com/coff33ninja/Todoist/security/code-scanning/2](https://github.com/coff33ninja/Todoist/security/code-scanning/2)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `process_query` and `get_categories` functions.

1. Import the `logging` module to log the error messages.
2. Configure the logging to write to a file or another logging handler as needed.
3. Replace the current exception handling to log the detailed error message and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevents the exposure of detailed error messages to the end user by logging them on the server and returning a generic error message instead.