### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,7 +9,7 @@ import os
 import sys
 from datetime import datetime
 from werkzeug.utils import secure_filename
-
+import logging
 # Ensure repository path is accessible
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from ai.nlu_processor import NLUProcessor
@@ -54,7 +54,8 @@ def process_query():
         return jsonify(result)
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        app.logger.error(f"Error processing query: {e}")
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @app.route("/api/categories", methods=["GET"])
@@ -68,7 +69,8 @@ def get_categories():
         conn.close()
         return jsonify({"categories": categories})
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        app.logger.error(f"Error getting categories: {e}")
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @app.route("/api/items", methods=["POST"])
@@ -152,7 +154,8 @@ def add_item():
         return jsonify({"message": "Item added successfully", "item": item})
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        app.logger.error(f"Error adding item: {e}")
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 @app.route("/api/items/<int:item_id>", methods=["DELETE"])
 def delete_item(item_id):


### PR DESCRIPTION
Potential fix for [https://github.com/coff33ninja/Todoist/security/code-scanning/3](https://github.com/coff33ninja/Todoist/security/code-scanning/3)

To fix the problem, we need to ensure that detailed exception messages are not exposed to end users. Instead, we should log the exception details on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic message.

- Modify the exception handling code in the `process_query`, `get_categories`, and `add_item` functions to log the exception details and return a generic error message.
- Add an import statement for the `logging` module to enable logging of exceptions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent the exposure of detailed exception messages to end users by logging exceptions on the server and returning a generic error message to the user.