### PR TITLE
Potential fix for code scanning alert no. 12: Flask app is run in debug mode

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -255,4 +255,5 @@ def upload_receipt():
         return jsonify({"error": "An internal error has occurred."}), 500
 
 if __name__ == "__main__":
-            app.run(debug=True, port=5000)
+            debug_mode = os.getenv("FLASK_DEBUG", "False").lower() == "true"
+            app.run(debug=debug_mode, port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/coff33ninja/Todoist/security/code-scanning/12](https://github.com/coff33ninja/Todoist/security/code-scanning/12)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can set the debug mode to `True` during development and `False` during production.

1. Import the `os` module if it is not already imported.
2. Modify the `app.run()` call to set the `debug` parameter based on an environment variable.
3. Update the `app.run()` call to use `os.getenv("FLASK_DEBUG", "False").lower() == "true"` to determine the debug mode.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fixes a code scanning alert by ensuring Flask app is not run in debug mode in production.